### PR TITLE
refactor: refine the setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Garoon と Google Calendar を双方向に同期します。
 ```sh
 $ git clone git@github.com:hiroppy/garoogle.git
 $ cd garoogle
+$ npm install --production
 $ cp .env.sample .env # and edit
 $ docker-compose up -d
 ```

--- a/docs/google-calendar.md
+++ b/docs/google-calendar.md
@@ -11,7 +11,7 @@ https://console.developers.google.com/cloud-resource-manager
 1.  プロジェクトを作成
 2.  認証情報のページへ行く https://console.developers.google.com/apis/credentials?project=xxxx
 3.  認証情報を作成 -> サービスアカウントキー
-4.  役割なしでサービスアカウントを選択し、JSON でダウンロード
+4.  `役割なし` でサービスアカウントを選択し、JSON でダウンロード
 5.  `GOOGLE_API_KEY_FILE`のパスをこのファイルのパスへ変更
 6.  ライブラリのページへ行く https://console.developers.google.com/apis/library?project=xxxx
 7.  Google Calendar API を検索し、有効にする
@@ -24,7 +24,7 @@ https://calendar.google.com/calendar
 2.  作ったら、左のサイドメニューのマイカレンダーからそのカレンダーの設定(設定と共有)を開く
 3.  カレンダーの統合からカレンダー ID を取得
 4.  `CALENDAR_ID`の名前を 3 で取得した名前にする(e.g. `xxx@group.calendar.google.com`)
-5.  カレンダーの設定の特定のユーザーとの共有からサービスアカウントのメールアドレスを追加し、予定の変更権限を付与する
+5.  カレンダーの設定の `特定のユーザーとの共有` からサービスアカウントのメールアドレスを追加し、予定の変更権限を付与する
 
 # 補足
 

--- a/docs/google-calendar.md
+++ b/docs/google-calendar.md
@@ -11,8 +11,10 @@ https://console.developers.google.com/cloud-resource-manager
 1.  プロジェクトを作成
 2.  認証情報のページへ行く https://console.developers.google.com/apis/credentials?project=xxxx
 3.  認証情報を作成 -> サービスアカウントキー
-4.  サービスアカウントを選択し、JSON でダウンロード
+4.  役割なしでサービスアカウントを選択し、JSON でダウンロード
 5.  `GOOGLE_API_KEY_FILE`のパスをこのファイルのパスへ変更
+6.  ライブラリのページへ行く https://console.developers.google.com/apis/library?project=xxxx
+7.  Google Calendar API を検索し、有効にする
 
 ## カレンダーを作成する
 
@@ -22,6 +24,9 @@ https://calendar.google.com/calendar
 2.  作ったら、左のサイドメニューのマイカレンダーからそのカレンダーの設定(設定と共有)を開く
 3.  カレンダーの統合からカレンダー ID を取得
 4.  `CALENDAR_ID`の名前を 3 で取得した名前にする(e.g. `xxx@group.calendar.google.com`)
+5.  カレンダーの設定の特定のユーザーとの共有からサービスアカウントのメールアドレスを追加し、予定の変更権限を付与する
+
+# 補足
 
 以下の記事を参考にしてください。  
 [Google カレンダー連携 - Garoon の予定を Google カレンダーに表示 -](https://developer.cybozu.io/hc/ja/articles/204426680-Google%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E9%80%A3%E6%90%BA-Garoon%E3%81%AE%E4%BA%88%E5%AE%9A%E3%82%92Google%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E3%81%AB%E8%A1%A8%E7%A4%BA-)


### PR DESCRIPTION
初めて使う人がセットアップ手順で間違えそうなところを補足してみました。
PRには含めてないのですが、以下も気になりました。

- GAROON_URLがサンプルがあったほうが良いかもしれません。最初 "https://garoon.example.com/" のように書いたところ、最初のアクセスで404 Not Foundとなり、動きませんでした。
  - 普遍的な説明が難しく、例えば「ガルーンを開き、クエリパラメータに `?WSDL` をつけ、`https://garoon.example.com/grn/cbpapi/schedule/api.csp?` のような文字列を探し、 `https://garoon.example.com/grn/` をGAROON_URLに設定する」とかでしょうか。。。
- GAROON_MY_NAMEに最初ログイン後の表記名（例：`名無しの権兵衛`）を書いたらログインできませんでした。GAROON_MY_IDとGAROON_MY_NAMEはなにか違うのでしょうか。